### PR TITLE
Update SPI callback prototype

### DIFF
--- a/Canbus_app/libraries/Spi_lib.c
+++ b/Canbus_app/libraries/Spi_lib.c
@@ -2,7 +2,7 @@
 
 // Function to callback for the SPI to work
 inline static void furi_hal_spi_bus_r_handle_event_callback(
-    FuriHalSpiBusHandle* handle,
+    const FuriHalSpiBusHandle* handle,
     FuriHalSpiBusHandleEvent event,
     const LL_SPI_InitTypeDef* preset) {
     if(event == FuriHalSpiBusHandleEventInit) {
@@ -48,7 +48,7 @@ inline static void furi_hal_spi_bus_r_handle_event_callback(
 }
 
 // Here is the CALLBACK
-static void spi_bus_callback(FuriHalSpiBusHandle* handle, FuriHalSpiBusHandleEvent event) {
+static void spi_bus_callback(const FuriHalSpiBusHandle* handle, FuriHalSpiBusHandleEvent event) {
     furi_hal_spi_bus_r_handle_event_callback(handle, event, SPEED_8MHZ);
 }
 


### PR DESCRIPTION
Just a minor touch up that was needed to build the app for the latest Unleashed/Momentum firmwares. By looking at the [original fw docs](https://developer.flipper.net/flipperzero/doxygen/furi__hal__spi__types_8h_source.html) I'd say that this patch should be needed to match that `FuriHalSpiBusHandleEventCallback` prototype too.